### PR TITLE
security: Pin all actions by SHA and add least-privilege permissions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,15 +24,15 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@07b33e6629a05469b63a9d89ceb37a47942645c9
       with:
         languages: ${{ matrix.language }}
 
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
       with:
         node-version: '20'
         cache: 'npm'
@@ -44,6 +44,6 @@ jobs:
       run: npm run build
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@07b33e6629a05469b63a9d89ceb37a47942645c9
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/driftguard-gate.yml
+++ b/.github/workflows/driftguard-gate.yml
@@ -1,13 +1,17 @@
 name: DriftGuard Gate (example)
 on:
   pull_request:
+
+permissions:
+  contents: read
+
 jobs:
   gate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
       - run: echo '{"status":"pass","summary":"demo"}' > driftguard-capsule.json
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with: 
           name: driftguard-capsule
           path: driftguard-capsule.json

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,15 +5,18 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
     
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
     
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
       with:
         node-version: '20'
         cache: 'npm'


### PR DESCRIPTION
## 🔒 Security Hardening

This PR pins all GitHub Actions by commit SHA and adds least-privilege permissions to prevent supply chain attacks.

### Changes Made

**Actions Pinned by SHA:**
- `actions/checkout@v4` → `@08eba0b27e820071cde6df949e0beb9ba4906955`
- `actions/setup-node@v4` → `@49933ea5288caeca8642d1e84afbd3f7d6820020`  
- `actions/upload-artifact@v4` → `@ea165f8d65b6e75b540449e92b4886f43607fa02`
- `github/codeql-action/*@v3` → `@07b33e6629a05469b63a9d89ceb37a47942645c9`

**Security Enhancements:**
- Added `permissions: { contents: read }` to all workflows
- CodeQL workflow already had proper permissions configured
- Follows GitHub security best practices for Actions

### Verification
- ✅ `rg -n "uses: .*@v" .github/workflows/ | wc -l` returns 0 (no unpinned actions)
- ✅ All workflows have explicit permissions blocks
- ✅ Maintains existing functionality while improving security posture

### References
- [GitHub Docs: Security hardening for Actions](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions)

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>